### PR TITLE
feat: add support for deb822 repos on deb13

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,10 +21,13 @@
     dest: "{{ openbao_gpg_key_path }}"
     mode: "0644"
     validate_certs: "{{ openbao_validate_certs }}"
+  when:
+    - not _openbao_use_deb822
 
 - name: Import OpenBao GPG key (apt)
   when:
     - ansible_facts['pkg_mgr'] == "apt"
+    - not _openbao_use_deb822
   block:
     - name: Install gnupg
       ansible.builtin.package:
@@ -55,13 +58,26 @@
   when:
     - ansible_facts['pkg_mgr'] == "apt"
 
-- name: Configure OpenBao APT repository
+- name: Configure OpenBao APT repository (deb822)
+  ansible.builtin.deb822_repository:
+    name: openbao
+    types: deb
+    uris: "{{ openbao_deb822_uris }}"
+    suites: "{{ openbao_deb822_suites }}"
+    components: "{{ openbao_deb822_components }}"
+    signed_by: "{{ openbao_gpg_key_url }}"
+    state: present
+  when:
+    - _openbao_use_deb822
+
+- name: Configure OpenBao APT repository (legacy)
   ansible.builtin.apt_repository:
     repo: "{{ openbao_apt_repository }}"
     filename: "openbao"
     state: present
   when:
     - ansible_facts['pkg_mgr'] == "apt"
+    - not _openbao_use_deb822
 
 - name: Configure OpenBao YUM repository
   ansible.builtin.yum_repository:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,17 @@
 openbao_gpg_key_url: "https://openbao.org/assets/openbao-gpg-pub-20240618.asc"
 openbao_gpg_key_path: "{{ openbao_download_dir.rstrip('/') + '/openbao_public_key.asc' }}"
 
+# Whether to use the deb822 repository format. Enabled on Debian 13 and later.
+_openbao_use_deb822: "{{ ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] | int >= 13 }}"
+
+# Legacy one-line APT repository (used on Debian < 13 and other apt-based distros).
 openbao_apt_repository: "deb [signed-by=/usr/share/keyrings/openbao-archive-keyring.gpg] https://pkgs.openbao.org/deb stable main"
+
+# deb822 APT repository fields (used on Debian 13+).
+openbao_deb822_uris: "https://pkgs.openbao.org/deb"
+openbao_deb822_suites: "stable"
+openbao_deb822_components: "main"
+
 openbao_yum_repository_baseurl: "https://pkgs.openbao.org/rpm/$basearch"
 openbao_yum_repository_gpgkey: "https://openbao.org/assets/openbao-gpg-pub-20240618.asc"
 


### PR DESCRIPTION
Hi, 

This PR adds support for the deb822 format, which is the default in debian 13.
